### PR TITLE
feat: add type definition, export symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 !/SECURITY.md
 !/tap-snapshots/
 !/test/
+!/index.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+declare class JSONParseError extends SyntaxError {
+    code: 'EJSONPARSE';
+    systemError: Error;
+    constructor(er: Error, txt: string, context: number, caller: Function | ((...a: any[]) => any));
+    get name(): string;
+    set name(_: string);
+    get [Symbol.toStringTag](): string;
+}
+declare const kIndent: unique symbol;
+declare const kNewline: unique symbol;
+declare namespace parseJson {
+    type Reviver = (this: any, key: string, value: any) => any;
+    type WithFormat<T> = T & {
+        [kIndent]?: string;
+        [kNewline]?: string;
+    };
+    type Scalar = string | number | null;
+    type JSONResult = {
+        [k: string]: JSONResult;
+    } | JSONResult[] | Scalar;
+    type Result = WithFormat<{
+        [k: string]: JSONResult;
+    }> | WithFormat<JSONResult[]> | Scalar;
+}
+declare const parseJson: {
+    (txt: string, reviver?: parseJson.Reviver, context?: number): parseJson.Result;
+    JSONParseError: typeof JSONParseError;
+    kIndent: typeof kIndent;
+    kNewline: typeof kNewline;
+    noExceptions(txt: string, reviver?: parseJson.Reviver): any;
+};
+export = parseJson;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,32 +1,21 @@
 declare class JSONParseError extends SyntaxError {
-    code: 'EJSONPARSE';
+    code: "EJSONPARSE";
     systemError: Error;
     constructor(er: Error, txt: string, context: number, caller: Function | ((...a: any[]) => any));
     get name(): string;
     set name(_: string);
     get [Symbol.toStringTag](): string;
 }
-declare const kIndent: unique symbol;
-declare const kNewline: unique symbol;
-declare namespace parseJson {
-    type Reviver = (this: any, key: string, value: any) => any;
-    type WithFormat<T> = T & {
-        [kIndent]?: string;
-        [kNewline]?: string;
-    };
-    type Scalar = string | number | null;
-    type JSONResult = {
-        [k: string]: JSONResult;
-    } | JSONResult[] | Scalar;
-    type Result = WithFormat<{
-        [k: string]: JSONResult;
-    }> | WithFormat<JSONResult[]> | Scalar;
-}
+type Reviver = (this: any, key: string, value: any) => any;
+type Replacer = ((this: any, key: string, value: any) => any) | (string | number)[] | null;
+type Scalar = string | number | null;
+type JSONResult = {
+    [k: string]: JSONResult;
+} | JSONResult[] | Scalar;
 declare const parseJson: {
-    (txt: string, reviver?: parseJson.Reviver, context?: number): parseJson.Result;
+    (txt: string, reviver?: Reviver, context?: number): JSONResult;
     JSONParseError: typeof JSONParseError;
-    kIndent: typeof kIndent;
-    kNewline: typeof kNewline;
-    noExceptions(txt: string, reviver?: parseJson.Reviver): any;
+    noExceptions(txt: string, reviver?: Reviver): any;
+    stringify(obj: any, replacer?: Replacer, indent?: string | number): string;
 };
 export = parseJson;

--- a/lib/index.js
+++ b/lib/index.js
@@ -119,6 +119,8 @@ const stripBOM = txt => String(txt).replace(/^\uFEFF/, '')
 
 module.exports = parseJson
 parseJson.JSONParseError = JSONParseError
+parseJson.kIndent = kIndent
+parseJson.kNewline = kNewline
 
 parseJson.noExceptions = (txt, reviver) => {
   try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -119,8 +119,6 @@ const stripBOM = txt => String(txt).replace(/^\uFEFF/, '')
 
 module.exports = parseJson
 parseJson.JSONParseError = JSONParseError
-parseJson.kIndent = kIndent
-parseJson.kNewline = kNewline
 
 parseJson.noExceptions = (txt, reviver) => {
   try {
@@ -128,4 +126,13 @@ parseJson.noExceptions = (txt, reviver) => {
   } catch (e) {
     // no exceptions
   }
+}
+
+parseJson.stringify = (obj, replacer, indent) => {
+  const space = indent === undefined ? obj[kIndent] : indent
+  const res = JSON.stringify(obj, replacer, space)
+  const nl = obj[kNewline] || '\n'
+  return space
+    ? (nl === '\n' ? res : res.split('\n').join(nl)) + nl
+    : res
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "files": [
     "bin/",
-    "lib/"
+    "lib/",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "tap",

--- a/test/index.js
+++ b/test/index.js
@@ -249,3 +249,9 @@ t.test('parse without exception', t => {
   t.same(parseJson.noExceptions(bom), obj, 'parses json buffer with bom')
   t.end()
 })
+
+t.test('export the symbols', t => {
+  t.equal(parseJson.kIndent, Symbol.for('indent'))
+  t.equal(parseJson.kNewline, Symbol.for('newline'))
+  t.end()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -250,8 +250,35 @@ t.test('parse without exception', t => {
   t.end()
 })
 
-t.test('export the symbols', t => {
-  t.equal(parseJson.kIndent, Symbol.for('indent'))
-  t.equal(parseJson.kNewline, Symbol.for('newline'))
+t.test('stringify', t => {
+  const obj = { a: 1, b: { c: 3 } }
+  const min = JSON.stringify(obj)
+  const twosp = JSON.stringify(obj, null, 2)
+  const spaces = ['', 2, '\t']
+  const nls = ['\n', '\r\n', '\n\n']
+  for (const space of spaces) {
+    for (const nl of nls) {
+      t.test(JSON.stringify({ space, nl }), t => {
+        const split = JSON.stringify(obj, null, space).split('\n')
+        const json = split.join(nl) + (split.length > 1 ? nl : '')
+        const parsed = parseJson(json)
+        t.same(parsed, obj, 'object parsed properly')
+        const stringified = parseJson.stringify(parsed)
+        t.equal(stringified, json, 'got same json back that we started with')
+        // trailing newline only matters if we are indenting
+        if (space) {
+          const noTrailingNL = split.join(nl)
+          const parsed2 = parseJson(noTrailingNL)
+          const stringified2 = parseJson.stringify(parsed2)
+          t.equal(stringified2, stringified, 'trailing newline added')
+          t.equal(parseJson.stringify(obj, null, ''), min, 'override to minify')
+          t.equal(parseJson.stringify(obj, null, 0), min, 'override to minify')
+          const twospWithNL = twosp.split('\n').join(nl) + nl
+          t.equal(parseJson.stringify(parsed2, null, 2), twospWithNL)
+        }
+        t.end()
+      })
+    }
+  }
   t.end()
 })


### PR DESCRIPTION
This makes it possible to use this library in a typescript environment, and take advantage of the indent/newline detection.

Without exporting the symbols themselves, typescript gets confused about the "unique symbol", since it isn't clever enough to verify that the same string literal passed to Symbol.for will result in the same Symbol object.  But, it does track object identities, so exposing the symbols on the export works fine.

Alternatively, exporting a `parseJson.stringify` method would be even handier, since then the consumer wouldn't have to worry about pulling the indent/newline off of the object.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
